### PR TITLE
Add support for Web Assembly (SwiftWASM) exclude UserDefaults etc

### DIFF
--- a/Sources/UserDefaults+Codable.swift
+++ b/Sources/UserDefaults+Codable.swift
@@ -31,6 +31,7 @@
 
 import Foundation
 
+#if !os(WASI)
 public extension UserDefaults {
 
     func encode<T: Encodable>(_ value: T, forKey key: String) throws {
@@ -56,3 +57,4 @@ public extension UserDefaults {
         }
     }
 }
+#endif

--- a/Tests/KeyValueDecoderTests.swift
+++ b/Tests/KeyValueDecoderTests.swift
@@ -732,6 +732,7 @@ final class KeyValueDecoderTests: XCTestCase {
         }
     }
 
+    #if !os(WASI)
     func testPlistCompatibleDecoder() throws {
         let plistAny = try PropertyListEncoder.encodeAny([1, 2, Int?.none, 4])
         XCTAssertEqual(
@@ -752,6 +753,7 @@ final class KeyValueDecoderTests: XCTestCase {
             [1, 2, Int?.none, 4]
         )
     }
+    #endif
 }
 
 func AssertThrowsDecodingError<T>(_ expression: @autoclosure () throws -> T,
@@ -890,6 +892,7 @@ struct SomeTypes: Codable, Equatable {
     var tString: String?
 }
 
+#if !os(WASI)
 private extension PropertyListEncoder {
     static func encodeAny<T: Encodable>(_ value: T) throws -> Any {
         let data = try PropertyListEncoder().encode(value)
@@ -903,3 +906,4 @@ private extension JSONEncoder {
         return try JSONSerialization.jsonObject(with: data, options: [])
     }
 }
+#endif

--- a/Tests/KeyValueEncoderTests.swift
+++ b/Tests/KeyValueEncoderTests.swift
@@ -638,6 +638,7 @@ final class KeyValueEncodedTests: XCTestCase {
         )
     }
 
+    #if !os(WASI)
     func testPlistCompatibleEncoder() throws {
         let keyValueAny = try KeyValueEncoder.makePlistCompatible().encode([1, 2, Int?.none, 4])
         XCTAssertEqual(
@@ -645,6 +646,7 @@ final class KeyValueEncodedTests: XCTestCase {
             [1, 2, Int?.none, 4]
         )
     }
+    #endif
 
     func testEncoder_Encodes_Dates() {
         let date = Date()
@@ -764,12 +766,14 @@ extension KeyValueEncoder.EncodedValue {
     }
 }
 
+#if !os(WASI)
 private extension PropertyListDecoder {
     static func decodeAny<T: Decodable>(_ type: T.Type, from value: Any?) throws -> T {
         let data = try PropertyListSerialization.data(fromPropertyList: value as Any, format: .xml, options: 0)
         return try PropertyListDecoder().decode(type, from: data)
     }
 }
+#endif
 
 private extension JSONDecoder {
     static func decodeAny<T: Decodable>(_ type: T.Type, from value: Any?) throws -> T {

--- a/Tests/UserDefaults+CodableTests.swift
+++ b/Tests/UserDefaults+CodableTests.swift
@@ -34,6 +34,7 @@
 import Foundation
 import XCTest
 
+#if !os(WASI)
 final class UserDefaultsCodableTests: XCTestCase {
 
     func testEncodes_Single() {
@@ -331,3 +332,4 @@ private extension UserDefaults {
         return UserDefaults(suiteName: "mock")!
     }
 }
+#endif


### PR DESCRIPTION
When building for web assembly (swiftwasm) some Foundation types are not available within the toolchain. 

`UserDefaults` and `PropertyListDecoder/Encoder` are conditionally removed when compiling for `os(WASI)`

[Instructions to install the toolchain](https://book.swiftwasm.org/getting-started/index.html).
Compile:
```
% xcrun --toolchain swiftwasm swift build --build-tests --triple wasm32-unknown-wasi
Building for debugging...
[7/7] Linking KeyValueCoderPackageTests.wasm
Build complete! (1.72s)
```

Run the tests:
```
% wasmer .build/debug/KeyValueCoderPackageTests.wasm 
Test Suite 'All tests' started at 2023-08-24 13:14:51.433
Test Suite 'testBundle.xctest' started at 2023-08-24 13:14:51.434
Test Suite 'KeyValueDecoderTests' started at 2023-08-24 13:14:51.434
Test Case 'KeyValueDecoderTests.testDecodes_Data' started at 2023-08-24 13:14:51.434
Test Case 'KeyValueDecoderTests.testDecodes_Data' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_Date' started at 2023-08-24 13:14:51.435
Test Case 'KeyValueDecoderTests.testDecodes_Date' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_Decimal' started at 2023-08-24 13:14:51.435
Test Case 'KeyValueDecoderTests.testDecodes_Decimal' passed (0.001 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_Double' started at 2023-08-24 13:14:51.436
Test Case 'KeyValueDecoderTests.testDecodes_Double' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_Float' started at 2023-08-24 13:14:51.437
Test Case 'KeyValueDecoderTests.testDecodes_Float' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_Ints' started at 2023-08-24 13:14:51.437
Test Case 'KeyValueDecoderTests.testDecodes_Ints' passed (0.001 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_KeyedBool' started at 2023-08-24 13:14:51.438
Test Case 'KeyValueDecoderTests.testDecodes_KeyedBool' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_KeyedInts' started at 2023-08-24 13:14:51.438
Test Case 'KeyValueDecoderTests.testDecodes_KeyedInts' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_KeyedRealNumbers' started at 2023-08-24 13:14:51.438
Test Case 'KeyValueDecoderTests.testDecodes_KeyedRealNumbers' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_KeyedUInts' started at 2023-08-24 13:14:51.438
Test Case 'KeyValueDecoderTests.testDecodes_KeyedUInts' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_NestedType' started at 2023-08-24 13:14:51.439
Test Case 'KeyValueDecoderTests.testDecodes_NestedType' passed (0.001 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_NestedUnkeyed' started at 2023-08-24 13:14:51.439
Test Case 'KeyValueDecoderTests.testDecodes_NestedUnkeyed' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_Null' started at 2023-08-24 13:14:51.440
Test Case 'KeyValueDecoderTests.testDecodes_Null' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_Optionals' started at 2023-08-24 13:14:51.440
Test Case 'KeyValueDecoderTests.testDecodes_Optionals' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_RawRepresentable' started at 2023-08-24 13:14:51.440
Test Case 'KeyValueDecoderTests.testDecodes_RawRepresentable' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_String' started at 2023-08-24 13:14:51.440
Test Case 'KeyValueDecoderTests.testDecodes_String' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_UInts' started at 2023-08-24 13:14:51.440
Test Case 'KeyValueDecoderTests.testDecodes_UInts' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_URL' started at 2023-08-24 13:14:51.440
Test Case 'KeyValueDecoderTests.testDecodes_URL' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedBool' started at 2023-08-24 13:14:51.441
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedBool' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedCount' started at 2023-08-24 13:14:51.441
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedCount' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedDecimals' started at 2023-08-24 13:14:51.441
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedDecimals' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedFloat' started at 2023-08-24 13:14:51.442
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedFloat' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedInts' started at 2023-08-24 13:14:51.442
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedInts' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedNil' started at 2023-08-24 13:14:51.442
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedNil' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedOptionals' started at 2023-08-24 13:14:51.442
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedOptionals' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedString' started at 2023-08-24 13:14:51.442
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedString' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedUInts' started at 2023-08-24 13:14:51.443
Test Case 'KeyValueDecoderTests.testDecodes_UnkeyedUInts' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testDecodingErrors' started at 2023-08-24 13:14:51.443
Test Case 'KeyValueDecoderTests.testDecodingErrors' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testKeyedContainer_Decodes_NestedKeyedContainer' started at 2023-08-24 13:14:51.443
Test Case 'KeyValueDecoderTests.testKeyedContainer_Decodes_NestedKeyedContainer' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testKeyedContainer_Decodes_NestedSuperContainer' started at 2023-08-24 13:14:51.443
Test Case 'KeyValueDecoderTests.testKeyedContainer_Decodes_NestedSuperContainer' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testKeyedContainer_Decodes_NestedUnkeyedContainer' started at 2023-08-24 13:14:51.444
Test Case 'KeyValueDecoderTests.testKeyedContainer_Decodes_NestedUnkeyedContainer' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testKeyedContainer_Decodes_SuperContainer' started at 2023-08-24 13:14:51.444
Test Case 'KeyValueDecoderTests.testKeyedContainer_Decodes_SuperContainer' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testKeyedContainer_ThrowsError_WhenKeyIsUknown' started at 2023-08-24 13:14:51.444
Test Case 'KeyValueDecoderTests.testKeyedContainer_ThrowsError_WhenKeyIsUknown' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testNSNumber_DoubleValue' started at 2023-08-24 13:14:51.444
Test Case 'KeyValueDecoderTests.testNSNumber_DoubleValue' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testNSNumber_Int64Value' started at 2023-08-24 13:14:51.444
Test Case 'KeyValueDecoderTests.testNSNumber_Int64Value' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testUnKeyedContainer_Decodes_NestedKeyedContainer' started at 2023-08-24 13:14:51.445
Test Case 'KeyValueDecoderTests.testUnKeyedContainer_Decodes_NestedKeyedContainer' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testUnKeyedContainer_Decodes_NestedUnkeyedContainer' started at 2023-08-24 13:14:51.445
Test Case 'KeyValueDecoderTests.testUnKeyedContainer_Decodes_NestedUnkeyedContainer' passed (0.0 seconds)
Test Case 'KeyValueDecoderTests.testUnKeyedContainer_Decodes_SuperContainer' started at 2023-08-24 13:14:51.445
Test Case 'KeyValueDecoderTests.testUnKeyedContainer_Decodes_SuperContainer' passed (0.0 seconds)
Test Suite 'KeyValueDecoderTests' passed at 2023-08-24 13:14:51.445
	 Executed 38 tests, with 0 failures (0 unexpected) in 0.009 (0.009) seconds
Test Suite 'KeyValueEncodedTests' started at 2023-08-24 13:14:51.445
Test Case 'KeyValueEncodedTests.testAnyCodingKey' started at 2023-08-24 13:14:51.445
Test Case 'KeyValueEncodedTests.testAnyCodingKey' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testEncoder_Encodes_Dates' started at 2023-08-24 13:14:51.446
Test Case 'KeyValueEncodedTests.testEncoder_Encodes_Dates' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testEncodes' started at 2023-08-24 13:14:51.446
Test Case 'KeyValueEncodedTests.testEncodes' passed (0.001 seconds)
Test Case 'KeyValueEncodedTests.testJSONCompatibleEncoder' started at 2023-08-24 13:14:51.447
Test Case 'KeyValueEncodedTests.testJSONCompatibleEncoder' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_Bool' started at 2023-08-24 13:14:51.448
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_Bool' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_Ints' started at 2023-08-24 13:14:51.448
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_Ints' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_NestedKeyedContainer' started at 2023-08-24 13:14:51.449
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_NestedKeyedContainer' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_NestedUnkeyedContainer' started at 2023-08-24 13:14:51.449
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_NestedUnkeyedContainer' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_Optionals' started at 2023-08-24 13:14:51.449
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_Optionals' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_RealNumbers' started at 2023-08-24 13:14:51.449
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_RealNumbers' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_SuperContainer' started at 2023-08-24 13:14:51.450
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_SuperContainer' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_UInts' started at 2023-08-24 13:14:51.450
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_UInts' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_URL' started at 2023-08-24 13:14:51.450
Test Case 'KeyValueEncodedTests.testKeyedContainer_Encodes_URL' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testNilEncodingStrategy_KeyedContainer' started at 2023-08-24 13:14:51.450
Test Case 'KeyValueEncodedTests.testNilEncodingStrategy_KeyedContainer' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testNilEncodingStrategy_SingleContainer' started at 2023-08-24 13:14:51.451
Test Case 'KeyValueEncodedTests.testNilEncodingStrategy_SingleContainer' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testNilEncodingStrategy_UnkeyedContainer' started at 2023-08-24 13:14:51.451
Test Case 'KeyValueEncodedTests.testNilEncodingStrategy_UnkeyedContainer' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_Bool' started at 2023-08-24 13:14:51.451
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_Bool' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_Duration' started at 2023-08-24 13:14:51.451
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_Duration' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_Ints' started at 2023-08-24 13:14:51.452
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_Ints' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_Optionals' started at 2023-08-24 13:14:51.452
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_Optionals' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_RawRepresentable' started at 2023-08-24 13:14:51.452
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_RawRepresentable' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_RealNumbers' started at 2023-08-24 13:14:51.452
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_RealNumbers' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_String' started at 2023-08-24 13:14:51.452
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_String' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_UInts' started at 2023-08-24 13:14:51.452
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_UInts' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_URL' started at 2023-08-24 13:14:51.453
Test Case 'KeyValueEncodedTests.testSingleContainer_Encodes_URL' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSingleContainer_ReturnsEmptyObject_WhenEmpty' started at 2023-08-24 13:14:51.453
Test Case 'KeyValueEncodedTests.testSingleContainer_ReturnsEmptyObject_WhenEmpty' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testSupportedCodableTypes' started at 2023-08-24 13:14:51.453
Test Case 'KeyValueEncodedTests.testSupportedCodableTypes' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_Bool' started at 2023-08-24 13:14:51.453
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_Bool' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_Ints' started at 2023-08-24 13:14:51.453
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_Ints' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_NestedKeyedContainer' started at 2023-08-24 13:14:51.453
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_NestedKeyedContainer' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_NestedUnkeyedContainer' started at 2023-08-24 13:14:51.453
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_NestedUnkeyedContainer' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_Optionals' started at 2023-08-24 13:14:51.454
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_Optionals' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_RawRepresentable' started at 2023-08-24 13:14:51.454
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_RawRepresentable' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_RealNumbers' started at 2023-08-24 13:14:51.454
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_RealNumbers' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_SuperContainer' started at 2023-08-24 13:14:51.454
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_SuperContainer' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_UInts' started at 2023-08-24 13:14:51.454
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_UInts' passed (0.0 seconds)
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_URL' started at 2023-08-24 13:14:51.454
Test Case 'KeyValueEncodedTests.testUnkeyedContainer_Encodes_URL' passed (0.0 seconds)
Test Suite 'KeyValueEncodedTests' passed at 2023-08-24 13:14:51.455
	 Executed 37 tests, with 0 failures (0 unexpected) in 0.007 (0.007) seconds
Test Suite 'testBundle.xctest' passed at 2023-08-24 13:14:51.455
	 Executed 75 tests, with 0 failures (0 unexpected) in 0.015 (0.015) seconds
Test Suite 'All tests' passed at 2023-08-24 13:14:51.455
	 Executed 75 tests, with 0 failures (0 unexpected) in 0.015 (0.015) seconds
```