### PR TITLE
Decode BinaryInteger types from Doubles when exactly represented

### DIFF
--- a/Sources/KeyValueDecoder.swift
+++ b/Sources/KeyValueDecoder.swift
@@ -155,7 +155,15 @@ private extension KeyValueDecoder {
                     throw DecodingError.typeMismatch(type, context)
                 }
                 return val
-            } else {
+            } else if let double = (value as? NSNumber)?.getDoubleValue() {
+                let val = T(double)
+                guard Double(val) == double else {
+                    let context = DecodingError.Context(codingPath: codingPath, debugDescription: "\(valueDescription) at \(codingPath.makeKeyPath()), cannot be exactly represented by \(type)")
+                    throw DecodingError.typeMismatch(type, context)
+                }
+                return val
+            }
+            else {
                 let context = DecodingError.Context(codingPath: codingPath, debugDescription: "Expected BinaryInteger at \(codingPath.makeKeyPath()), found \(valueDescription)")
                 if decodeNil() {
                     throw DecodingError.valueNotFound(type, context)

--- a/Tests/KeyValueDecoderTests.swift
+++ b/Tests/KeyValueDecoderTests.swift
@@ -103,6 +103,14 @@ final class KeyValueDecoderTests: XCTestCase {
             try KeyValueDecoder.decode(Int16.self, from: NSNumber(10)),
             10
         )
+        XCTAssertEqual(
+            try KeyValueDecoder.decode(Int16.self, from: 10.0),
+            10
+        )
+        XCTAssertEqual(
+            try KeyValueDecoder.decode(Int16.self, from: NSNumber(10.0)),
+            10
+        )
         XCTAssertThrowsError(
             try KeyValueDecoder.decode(Int8.self, from: Int16.max)
         )
@@ -118,6 +126,12 @@ final class KeyValueDecoderTests: XCTestCase {
         XCTAssertThrowsError(
             try KeyValueDecoder.decode(Int16.self, from: NSNull())
         )
+        XCTAssertThrowsError(
+            try KeyValueDecoder.decode(Int8.self, from: 10.1)
+        )
+        XCTAssertThrowsError(
+            try KeyValueDecoder.decode(Int8.self, from: NSNumber(10.1))
+        )
     }
 
     func testDecodes_UInts() {
@@ -127,6 +141,14 @@ final class KeyValueDecoderTests: XCTestCase {
         )
         XCTAssertEqual(
             try KeyValueDecoder.decode(UInt8.self, from: NSNumber(10)),
+            10
+        )
+        XCTAssertEqual(
+            try KeyValueDecoder.decode(UInt8.self, from: 10.0),
+            10
+        )
+        XCTAssertEqual(
+            try KeyValueDecoder.decode(UInt8.self, from: NSNumber(10.0)),
             10
         )
         XCTAssertThrowsError(
@@ -140,6 +162,12 @@ final class KeyValueDecoderTests: XCTestCase {
         )
         XCTAssertThrowsError(
             try KeyValueDecoder.decode(UInt8.self, from: NSNull())
+        )
+        XCTAssertThrowsError(
+            try KeyValueDecoder.decode(UInt8.self, from: 10.1)
+        )
+        XCTAssertThrowsError(
+            try KeyValueDecoder.decode(UInt8.self, from: NSNumber(10.1))
         )
     }
 
@@ -480,8 +508,8 @@ final class KeyValueDecoderTests: XCTestCase {
 
     func testDecodes_UnkeyedInts() {
         XCTAssertEqual(
-            try KeyValueDecoder.decode([Int].self, from: [-10, 20, 30]),
-            [-10, 20, 30]
+            try KeyValueDecoder.decode([Int].self, from: [-10, 20, 30, 40.0, -50.0]),
+            [-10, 20, 30, 40, -50]
         )
         XCTAssertEqual(
             try KeyValueDecoder.decode([Int8].self, from: [10, -20, 30]),
@@ -610,8 +638,8 @@ final class KeyValueDecoderTests: XCTestCase {
 
     func testDecodes_UnkeyedUInts() {
         XCTAssertEqual(
-            try KeyValueDecoder.decode([UInt].self, from: [10, 20, 30]),
-            [10, 20, 30]
+            try KeyValueDecoder.decode([UInt].self, from: [10, 20, 30, 40.0]),
+            [10, 20, 30, 40]
         )
         XCTAssertEqual(
             try KeyValueDecoder.decode([UInt8].self, from: [10, 20, 30]),


### PR DESCRIPTION
Allows any [BinaryInteger](https://developer.apple.com/documentation/swift/binaryinteger) type to be decoded from a floating point values that do no contain decimal places.

For example, the following now decodes:

```swift
// [10, 20, -30]
let values = try KeyValueDecoder().decode([Int].self, from: [10, 20.0, -30.0])
```

But the following throws an error:

```swift
// throws DecodingError.typeMismatch 'Double at SELF[1], cannot be exactly represented by Int'
let values = try KeyValueDecoder().decode([Int].self, from: [10, 20.5, -30.0])
```