### PR TITLE
Struct sendable

### DIFF
--- a/Sources/KeyValueDecoder.swift
+++ b/Sources/KeyValueDecoder.swift
@@ -33,7 +33,7 @@ import CoreFoundation
 import Foundation
 
 /// Top level encoder that converts `[String: Any]`, `[Any]` or `Any` into `Codable` types.
-public final class KeyValueDecoder {
+public struct KeyValueDecoder: Sendable {
 
     /// Contextual user-provided information for use during encoding.
     public var userInfo: [CodingUserInfoKey: any Sendable]
@@ -94,7 +94,7 @@ extension KeyValueDecoder: TopLevelDecoder {
 extension KeyValueDecoder {
 
     static func makePlistCompatible() -> KeyValueDecoder {
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
         decoder.nilDecodingStrategy = .stringNull
         return decoder
     }

--- a/Sources/KeyValueEncoder.swift
+++ b/Sources/KeyValueEncoder.swift
@@ -32,7 +32,7 @@
 import Foundation
 
 /// Top level encoder that converts `Codable` instances into loosely typed `[String: Any]`, `[Any]` or `Any`.
-public final class KeyValueEncoder {
+public struct KeyValueEncoder: Sendable {
 
     /// Contextual user-provided information for use during encoding.
     public var userInfo: [CodingUserInfoKey: any Sendable]
@@ -85,7 +85,7 @@ extension KeyValueEncoder: TopLevelEncoder {
 extension KeyValueEncoder {
 
     static func makePlistCompatible() -> KeyValueEncoder {
-        let encoder = KeyValueEncoder()
+        var encoder = KeyValueEncoder()
         encoder.nilEncodingStrategy = .stringNull
         return encoder
     }

--- a/Tests/KeyValueDecoderTests.swift
+++ b/Tests/KeyValueDecoderTests.swift
@@ -146,7 +146,7 @@ struct KeyValueDecoderTests {
 
     @Test
     func decodesRounded_Ints() throws {
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
         decoder.intDecodingStrategy = .rounding(rule: .toNearestOrAwayFromZero)
 
         #expect(
@@ -235,7 +235,7 @@ struct KeyValueDecoderTests {
 
     @Test
     func decodesRounded_UInts() throws {
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
         decoder.intDecodingStrategy = .rounding(rule: .toNearestOrAwayFromZero)
 
         #expect(
@@ -422,7 +422,7 @@ struct KeyValueDecoderTests {
 
     @Test
     func decodes_Null() throws {
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
         decoder.nilDecodingStrategy = .default
 
         #expect(throws: (any Error).self) {
@@ -461,7 +461,7 @@ struct KeyValueDecoderTests {
 
     @Test
     func decodes_UnkeyedOptionals() throws {
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
 
         decoder.nilDecodingStrategy = .removed
         #expect(
@@ -704,7 +704,7 @@ struct KeyValueDecoderTests {
 
     @Test
     func decodes_UnkeyedNil() throws {
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
         decoder.nilDecodingStrategy = .default
 
         #expect(
@@ -917,7 +917,7 @@ struct KeyValueDecoderTests {
             UInt8(from: Double.nan, using: .clamping(roundingRule: nil)) == nil
         )
 
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
         decoder.intDecodingStrategy = .clamping(roundingRule: .toNearestOrAwayFromZero)
         #expect(
             try decoder.decode([Int8].self, from: [10, 20.5, 1000, -Double.infinity]) == [
@@ -1004,7 +1004,7 @@ private extension KeyValueDecoder {
             return try closure(&container)
         }
 
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
         decoder.userInfo[.decoder] = proxy as any DecodingProxy
         _ = try decoder.decode(StubDecoder.self, from: value)
         return proxy.result!
@@ -1019,14 +1019,14 @@ private extension KeyValueDecoder {
             return try closure(&container)
         }
 
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
         decoder.userInfo[.decoder] = proxy as any DecodingProxy
         _ = try decoder.decode(StubDecoder.self, from: value)
         return proxy.result!
     }
 
     static func makeJSONCompatible() -> KeyValueDecoder {
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
         decoder.nilDecodingStrategy = .nsNull
         return decoder
     }

--- a/Tests/KeyValueEncoderTests.swift
+++ b/Tests/KeyValueEncoderTests.swift
@@ -540,7 +540,7 @@ struct KeyValueEncodedTests {
 
     @Test
     func nilEncodingStrategy_SingleContainer() throws {
-        let encoder = KeyValueEncoder()
+        var encoder = KeyValueEncoder()
 
         encoder.nilEncodingStrategy = .removed
         #expect(
@@ -568,7 +568,7 @@ struct KeyValueEncodedTests {
 
     @Test
     func nilEncodingStrategy_UnkeyedContainer() throws {
-        let encoder = KeyValueEncoder()
+        var encoder = KeyValueEncoder()
 
         encoder.nilEncodingStrategy = .removed
         #expect(
@@ -677,7 +677,7 @@ private extension KeyValueEncoder {
 
     static func encodeSingleValue(nilEncodingStrategy: NilEncodingStrategy = .default,
                                   with closure: (inout any SingleValueEncodingContainer) throws -> Void) throws -> EncodedValue {
-        let encoder = KeyValueEncoder()
+        var encoder = KeyValueEncoder()
         encoder.nilEncodingStrategy = nilEncodingStrategy
         return try encoder.encodeValue {
             var container = $0.singleValueContainer()
@@ -692,11 +692,12 @@ private extension KeyValueEncoder {
         }
     }
 
-    static func encodeKeyedValue<K: CodingKey>(keyedBy: K.Type = K.self,
-                                               nilEncodingStrategy: NilEncodingStrategy = .default,
-                                               with closure: @escaping (inout KeyedEncodingContainer<K>) throws -> Void) throws
-        -> EncodedValue {
-        let encoder = KeyValueEncoder()
+    static func encodeKeyedValue<K: CodingKey>(
+        keyedBy: K.Type = K.self,
+        nilEncodingStrategy: NilEncodingStrategy = .default,
+        with closure: @escaping (inout KeyedEncodingContainer<K>) throws -> Void
+    ) throws -> EncodedValue {
+        var encoder = KeyValueEncoder()
         encoder.nilEncodingStrategy = nilEncodingStrategy
         return try encoder.encodeValue {
             var container = $0.container(keyedBy: K.self)
@@ -711,7 +712,7 @@ private extension KeyValueEncoder {
     }
 
     static func makeJSONCompatible() -> KeyValueEncoder {
-        let encoder = KeyValueEncoder()
+        var encoder = KeyValueEncoder()
         encoder.nilEncodingStrategy = .nsNull
         return encoder
     }

--- a/Tests/KeyValueEncoderXCTests.swift
+++ b/Tests/KeyValueEncoderXCTests.swift
@@ -34,7 +34,7 @@
 
 import XCTest
 
-final class KeyValueEncodedTests: XCTestCase {
+final class KeyValueEncodedXCTests: XCTestCase {
 
     typealias EncodedValue = KeyValueEncoder.EncodedValue
 
@@ -543,7 +543,7 @@ final class KeyValueEncodedTests: XCTestCase {
     }
 
     func testNilEncodingStrategy_SingleContainer() {
-        let encoder = KeyValueEncoder()
+        var encoder = KeyValueEncoder()
 
         encoder.nilEncodingStrategy = .removed
         XCTAssertNil(
@@ -572,7 +572,7 @@ final class KeyValueEncodedTests: XCTestCase {
     }
 
     func testNilEncodingStrategy_UnkeyedContainer() {
-        let encoder = KeyValueEncoder()
+        var encoder = KeyValueEncoder()
 
         encoder.nilEncodingStrategy = .removed
         XCTAssertEqual(
@@ -670,7 +670,7 @@ private extension KeyValueEncoder {
 
     static func encodeSingleValue(nilEncodingStrategy: NilEncodingStrategy = .default,
                                   with closure: (inout any SingleValueEncodingContainer) throws -> Void) throws -> EncodedValue {
-        let encoder = KeyValueEncoder()
+        var encoder = KeyValueEncoder()
         encoder.nilEncodingStrategy = nilEncodingStrategy
         return try encoder.encodeValue {
             var container = $0.singleValueContainer()
@@ -688,7 +688,7 @@ private extension KeyValueEncoder {
     static func encodeKeyedValue<K: CodingKey>(keyedBy: K.Type = K.self,
                                                nilEncodingStrategy: NilEncodingStrategy = .default,
                                                with closure: @escaping (inout KeyedEncodingContainer<K>) throws -> Void) throws -> EncodedValue {
-        let encoder = KeyValueEncoder()
+        var encoder = KeyValueEncoder()
         encoder.nilEncodingStrategy = nilEncodingStrategy
         return try encoder.encodeValue {
             var container = $0.container(keyedBy: K.self)
@@ -703,7 +703,7 @@ private extension KeyValueEncoder {
     }
 
     static func makeJSONCompatible() -> KeyValueEncoder {
-        let encoder = KeyValueEncoder()
+        var encoder = KeyValueEncoder()
         encoder.nilEncodingStrategy = .nsNull
         return encoder
     }


### PR DESCRIPTION
Convert the top level types `KeyValueEncoder` and `KeyValueDecoder` from `class` to `struct` so they can easily become `Sendable` without adding a lock.

While this is a API change breaking change the fixit is easy convert `let decoder` to `var decoder` where required. 

Only code that adjusts the decoding strategies will be impacted.