### PR TITLE
snake_case keys via Encoding/Decoding strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,27 @@ decoder.intDecodingStrategy = .clamping(roundingRule: .toNearestOrAwayFromZero)
 let values = try decoder.decode([Int8].self, from: [10, 20.5, 1000, -Double.infinity])
 ```
 
+## Key Strategy
+
+Keys can be encoded to snake_case by setting the strategy:
+
+```swift
+var encoder = KeyValueEncoder()
+encoder.keyEncodingStrategy = .convertToSnakeCase
+
+// ["first_name": "fish", "surname": "chips"]
+let dict = try encoder.encode(Person(firstName: "fish", surname: "chips))
+```
+
+And decoded from snake_case:
+
+```swift
+var decoder = KeyValueDecoder()
+decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+let person = try decoder.decode(Person.self, from: dict)
+```
+
 ## UserDefaults
 Encode and decode [`Codable`](https://developer.apple.com/documentation/swift/codable) types with [`UserDefaults`](https://developer.apple.com/documentation/foundation/userdefaults):
 

--- a/Tests/KeyValueDecoderTests.swift
+++ b/Tests/KeyValueDecoderTests.swift
@@ -449,6 +449,28 @@ struct KeyValueDecoderTests {
     }
 
     @Test
+    func decodes_SnakeCase() throws {
+        let dict: [String: Any] = [
+            "first_name": "fish",
+            "surname": "chips",
+            "profile_url": "drop",
+            "rel_nodes_link": ["ocean": ["first_name": "shrimp", "surname": "anemone"]]
+        ]
+
+        var decoder = KeyValueDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        #expect(
+            try decoder.decode(SnakeNode.self, from: dict) == SnakeNode(
+                firstName: "fish",
+                lastName: "chips",
+                profileURL: "drop",
+                relNODESLink: ["ocean": SnakeNode(firstName: "shrimp", lastName: "anemone")]
+            )
+        )
+    }
+
+    @Test
     func decodes_NestedUnkeyed() throws {
         let decoder = KeyValueDecoder()
 

--- a/Tests/KeyValueEncoderTests.swift
+++ b/Tests/KeyValueEncoderTests.swift
@@ -366,6 +366,24 @@ struct KeyValueEncodedTests {
     }
 
     @Test
+    func keyedContainer_Encodes_SnakeCase() throws {
+        let shrimp = SnakeNode(firstName: "shrimp", lastName: "anemone")
+        let node = SnakeNode(firstName: "fish", lastName: "chips", profileURL: "drop", relNODESLink: ["ocean": shrimp])
+
+        var encoder = KeyValueEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+
+        #expect(
+            try encoder.encode(node) as? NSDictionary == [
+                "first_name": "fish",
+                "surname": "chips",
+                "profile_url": "drop",
+                "rel_nodes_link": ["ocean": ["first_name": "shrimp", "surname": "anemone"]]
+            ]
+        )
+    }
+
+    @Test
     func unkeyedContainer_Encodes_Optionals() throws {
         #expect(
             try KeyValueEncoder.encodeUnkeyedValue {
@@ -744,6 +762,18 @@ struct Node: Codable, Equatable {
 
     enum RelatedKeys: String, CodingKey {
         case left, right
+    }
+}
+
+struct SnakeNode: Codable, Equatable {
+    var firstName: String
+    var lastName: String
+    var profileURL: String?
+    var relNODESLink: [String: SnakeNode]?
+
+    enum CodingKeys: String, CodingKey {
+        case firstName, profileURL, relNODESLink
+        case lastName = "surname"
     }
 }
 


### PR DESCRIPTION
Keys can be encoded to snake_case by setting the strategy:

```swift
var encoder = KeyValueEncoder()
encoder.keyEncodingStrategy = .convertToSnakeCase

// ["first_name": "fish", "surname": "chips"]
let dict = try encoder.encode(Person(firstName: "fish", surname: "chips))
```

And decoded from snake_case:

```swift
var decoder = KeyValueDecoder()
decoder.keyDecodingStrategy = .convertFromSnakeCase

let person = try decoder.decode(Person.self, from: dict)
```