### PR TITLE
Swift 6.2 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,20 @@ jobs:
           junit: result-swift-testing.xml
           coverage: .build/debug/codecov/KeyValueCoder.json
 
+  xcode_26:
+    runs-on: macos-15
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.0.app/Contents/Developer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Version
+        run: swift --version
+      - name: Build
+        run: swift build --build-tests
+      - name: Test
+        run: swift test --skip-build
+
   xcode_16_2:
     runs-on: macos-15
     env:
@@ -64,36 +78,9 @@ jobs:
       - name: Test
         run: swift test --skip-build
 
-  xcode_15_2:
-    runs-on: macos-14
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_15.2.app/Contents/Developer
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Version
-        run: swift --version
-      - name: Build
-        run: swift build --build-tests
-      - name: Test
-        run: swift test --skip-build
-
   linux_swift_5_10:
     runs-on: ubuntu-latest
     container: swift:5.10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Version
-        run: swift --version
-      - name: Build
-        run: swift build --build-tests
-      - name: Test
-        run: swift test --skip-build
-
-  linux_swift_5_9:
-    runs-on: ubuntu-latest
-    container: swift:5.9
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -120,6 +107,19 @@ jobs:
   linux_swift_6_1:
     runs-on: ubuntu-latest
     container: swift:6.1.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Version
+        run: swift --version
+      - name: Build
+        run: swift build --build-tests
+      - name: Test
+        run: swift test --skip-build
+
+  linux_swift_6_2:
+    runs-on: ubuntu-latest
+    container: swiftlang/swift:nightly-6.2-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Package@swift-5.10.swift
+++ b/Package@swift-5.10.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Updating actions to build using Xcode 26 beta and swift 6.2 nightlies.

Removing Swift 5.9 support