### PR TITLE
Date Encoding/Decoding Strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,34 @@ let user = try KeyValueDecoder().decode(User.self, from: [["id": 1, "name": "Her
 let ascii = try KeyValueDecoder().decode([UInt8].self, from: [10, 100, 1000])
 ```
 
+
+## Date Encoding/Decoding Strategy
+
+The encoding of `Date` can be adjusted by setting the strategy.  
+
+By default `Date` instances are encoded by simply casting to `Any` but this adjusted by setting the strategy.  
+
+The default strategy casts to `Any` leaving the instance unchanged:
+
+```swift
+var encoder = KeyValueEncoder()
+encoder.dateEncodingStrategy = .date
+
+// Date()
+let any = try encoder.encode(Date())
+```
+
+ISO8601 compatible strings can be used:
+
+```swift
+encoder.dateEncodingStrategy = .iso8601()
+
+// "1970-01-01T00:00:00Z"
+let any = try encoder.encode(Date(timeIntervalSince1970: 0))
+```
+
+Epochs are also supported using `.secondsSince1970` and `millisecondsSince1970`.
+
 ## Nil Encoding/Decoding Strategy
 
 The encoding of `Optional.none` can be adjusted by setting the strategy.  

--- a/Tests/KeyValueDecoderTests.swift
+++ b/Tests/KeyValueDecoderTests.swift
@@ -403,11 +403,35 @@ struct KeyValueDecoderTests {
 
     @Test
     func decodes_Date() throws {
-        let decoder = KeyValueDecoder()
+        var decoder = KeyValueDecoder()
+        let referenceDate = Date(timeIntervalSinceReferenceDate: 0)
 
-        let date = Date(timeIntervalSinceReferenceDate: 0)
+        decoder.dateDecodingStrategy = .date
         #expect(
-            try decoder.decode(Date.self, from: date) == date
+            try decoder.decode(Date.self, from: referenceDate) == referenceDate
+        )
+
+        decoder.dateDecodingStrategy = .iso8601()
+        #expect(
+            try decoder.decode(Date.self, from: "2001-01-01T00:00:00Z") == referenceDate
+        )
+        #expect(throws: DecodingError.self) {
+            try decoder.decode(Date.self, from: "2001-01-01")
+        }
+
+        decoder.dateDecodingStrategy = .iso8601(options: [.withInternetDateTime, .withFractionalSeconds])
+        #expect(
+            try decoder.decode(Date.self, from: "2001-01-01T00:00:00.000Z") == referenceDate
+        )
+
+        decoder.dateDecodingStrategy = .millisecondsSince1970
+        #expect(
+            try decoder.decode(Date.self, from: 978307200000) == referenceDate
+        )
+
+        decoder.dateDecodingStrategy = .secondsSince1970
+        #expect(
+            try decoder.decode(Date.self, from: 978307200) == referenceDate
         )
     }
 

--- a/Tests/KeyValueEncoderXCTests.swift
+++ b/Tests/KeyValueEncoderXCTests.swift
@@ -87,7 +87,7 @@ final class KeyValueEncodedXCTests: XCTestCase {
             try KeyValueEncoder.encodeSingleValue {
                 try $0.encode(URL(string: "fish.com")!)
             },
-            EncodedValue(URL(string: "fish.com")!)
+            .value(URL(string: "fish.com")!)
         )
     }
 
@@ -765,6 +765,20 @@ extension KeyValueEncoder.EncodedValue {
             return self
         }
     }
+}
+
+private extension KeyValueEncoder.EncodedValue {
+    static func isSupportedValue(_ value: Any) -> Bool {
+        Self.makeValue(for: value, using: .default) != nil
+    }
+}
+
+private extension KeyValueEncoder.EncodingStrategy {
+    static let `default` = Self(
+        optionals: .default,
+        keys: .useDefaultKeys,
+        dates: .date
+    )
 }
 
 #if !os(WASI)


### PR DESCRIPTION
Adds `DateEncoding/DecodingStrategy` allowing for dates to be encoded using alternate formats by setting the strategy.  

The (existing) default strategy casts to `Any` leaving the instance unchanged:

```swift
var encoder = KeyValueEncoder()
encoder.dateEncodingStrategy = .date

// Date()
let any = try encoder.encode(Date())
```

ISO8601 compatible strings can be used:

```swift
encoder.dateEncodingStrategy = .iso8601()

// "1970-01-01T00:00:00Z"
let any = try encoder.encode(Date(timeIntervalSince1970: 0))
```