### PR TITLE
custom date coding via closures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,10 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: 🔍 Xcode Select
-        run: |
-          XCODE_PATH=`mdfind "kMDItemCFBundleIdentifier == 'com.apple.dt.Xcode' && kMDItemVersion == '16.*'" -onlyin /Applications | head -1`
-          echo "DEVELOPER_DIR=$XCODE_PATH/Contents/Developer" >> $GITHUB_ENV
       - name: Version
         run: swift --version
       - name: Build

--- a/Tests/KeyValueEncoderXCTests.swift
+++ b/Tests/KeyValueEncoderXCTests.swift
@@ -769,7 +769,11 @@ extension KeyValueEncoder.EncodedValue {
 
 private extension KeyValueEncoder.EncodedValue {
     static func isSupportedValue(_ value: Any) -> Bool {
-        Self.makeValue(for: value, using: .default) != nil
+        do {
+            return try Self.makeValue(for: value, using: .default) != nil
+        } catch {
+            return false
+        }
     }
 }
 


### PR DESCRIPTION
Adds custom closure based strategy to the [recently added](https://github.com/swhitty/KeyValueCoder/pull/14) Date Encoding/Decoding strategy allowing any date format to be used.

Updates `.iso8601()` strategy to pass a closure that includes the `ISO8601Formatter`.

Catches errors from these closures and wraps in `DecodingError` / `EncodingError`.