### PR TITLE
Support watchOS 32bit

### DIFF
--- a/Sources/KeyValueDecoder.swift
+++ b/Sources/KeyValueDecoder.swift
@@ -381,10 +381,10 @@ private extension KeyValueDecoder {
             case .date:
                 return try getValue()
             case .millisecondsSince1970:
-                return try Date(timeIntervalSince1970: TimeInterval(decode(Int.self)) / 1000)
+                return try Date(timeIntervalSince1970: TimeInterval(decode(Int64.self)) / 1000)
 
             case .secondsSince1970:
-                return try Date(timeIntervalSince1970: TimeInterval(decode(Int.self)))
+                return try Date(timeIntervalSince1970: TimeInterval(decode(Int64.self)))
 
             case .custom(let transform):
                 do {

--- a/Sources/KeyValueEncoder.swift
+++ b/Sources/KeyValueEncoder.swift
@@ -755,9 +755,9 @@ extension KeyValueEncoder.EncodedValue {
         case .custom(let transform):
             return try .value(transform(date))
         case .millisecondsSince1970:
-            return .value(Int(date.timeIntervalSince1970 * 1000))
+            return .value(Int64(date.timeIntervalSince1970 * 1000))
         case .secondsSince1970:
-            return .value(Int(date.timeIntervalSince1970))
+            return .value(Int64(date.timeIntervalSince1970))
         }
     }
 }

--- a/Tests/KeyValueDecoderTests.swift
+++ b/Tests/KeyValueDecoderTests.swift
@@ -425,7 +425,7 @@ struct KeyValueDecoderTests {
 
         decoder.dateDecodingStrategy = .millisecondsSince1970
         #expect(
-            try decoder.decode(Date.self, from: 978307200000) == referenceDate
+            try decoder.decode(Date.self, from: Int64(978307200000)) == referenceDate
         )
 
         decoder.dateDecodingStrategy = .secondsSince1970

--- a/Tests/KeyValueEncoderTests.swift
+++ b/Tests/KeyValueEncoderTests.swift
@@ -687,12 +687,12 @@ struct KeyValueEncodedTests {
 
         encoder.dateEncodingStrategy = .millisecondsSince1970
         #expect(
-            try encoder.encode(referenceDate) as? Int == 978307200000
+            try encoder.encode(referenceDate) as? Int64 == 978307200000
         )
 
         encoder.dateEncodingStrategy = .secondsSince1970
         #expect(
-            try encoder.encode(referenceDate) as? Int == 978307200
+            try encoder.encode(referenceDate) as? Int64 == 978307200
         )
 
 #if compiler(>=6.1)


### PR DESCRIPTION
https://github.com/swhitty/KeyValueCoder/pull/14 added ability to encode/decode dates to integers using `.millisecondsSince1970` and `.secondsSince1970` but on `arm64_32` environments (some watchOS) this overflows because `Int` is only 32 bits.

This PR updates the encoding/decoding to explicitly use `Int64` for this field.